### PR TITLE
feat: add FR/EN language switcher

### DIFF
--- a/src/components/AboutUS/index.tsx
+++ b/src/components/AboutUS/index.tsx
@@ -2,8 +2,10 @@ import { motion } from "framer-motion";
 import { useInView } from "framer-motion";
 import { useRef } from "react";
 import images from "../../assets/pictures";
+import { useLanguage } from "../../i18n/LanguageContext";
 
 const AboutUs = () => {
+  const { t } = useLanguage();
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, amount: 0.3 });
 
@@ -106,7 +108,7 @@ const AboutUs = () => {
                   ease: "easeInOut",
                 }}
               />
-              Glevosys
+              {t.about.badge}
             </motion.span>
           </motion.div>
           <motion.h2
@@ -127,7 +129,7 @@ const AboutUs = () => {
                 ease: [0.22, 1, 0.36, 1],
               }}
             >
-              Qui sommes-nous ?
+              {t.about.heading}
             </motion.span>
           </motion.h2>
           <motion.div
@@ -138,9 +140,9 @@ const AboutUs = () => {
           />
           <motion.div variants={itemVariants}>
             <p className="text-gray-600 text-lg lg:text-xl leading-relaxed text-justify lg:text-left">
-              {`GlevoSys est une entreprise technologique spécialisée dans la transformation numérique des grandes organisations africaines. Inspirée par l'héritage des leaders visionnaires du continent, notre mission est de concevoir, intégrer et sécuriser des solutions numériques à forte valeur ajoutée, allant du cloud et de l'intelligence artificielle au développement d'applications et à la cybersécurité. Nous accompagnons les entreprises dans la modernisation de leurs systèmes, l'optimisation de leurs performances et la montée en compétences de leurs équipes.`
+              {t.about.description
                 .split(". ")
-                .map((sentence, index) => (
+                .map((sentence, index, arr) => (
                   <motion.span
                     key={index}
                     className="inline-block"
@@ -155,7 +157,7 @@ const AboutUs = () => {
                     }}
                   >
                     {sentence}
-                    {index < 2 ? ". " : "."}
+                    {index < arr.length - 1 ? ". " : "."}
                   </motion.span>
                 ))}
             </p>
@@ -173,8 +175,10 @@ const AboutUs = () => {
             animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
             transition={{ delay: 1.4, duration: 0.6 }}
           >
-            Nous choisissons des outils en fonction de vos enjeux,{" "}
-            <span className="text-blue-600 font-semibold">pas l'inverse.</span>
+            {t.about.toolsTagline}{" "}
+            <span className="text-blue-600 font-semibold">
+              {t.about.toolsEmphasis}
+            </span>
           </motion.p>
           <div className="relative overflow-hidden w-full">
             <div className="absolute left-0 top-0 bottom-0 w-32 bg-gradient-to-r from-white to-transparent z-10" />

--- a/src/components/Contact/index.tsx
+++ b/src/components/Contact/index.tsx
@@ -1,8 +1,10 @@
 import { motion } from "framer-motion";
 import { useInView } from "framer-motion";
 import { useRef } from "react";
+import { useLanguage } from "../../i18n/LanguageContext";
 
 const Contact = () => {
+  const { t } = useLanguage();
   const sectionRef = useRef(null);
   const isInView = useInView(sectionRef, { once: true, amount: 0.2 });
   const containerVariants = {
@@ -75,6 +77,12 @@ const Contact = () => {
     window.location.href = `mailto:contact@glevosys.com?subject=${subject}&body=${body}`;
   };
 
+  const contactItems = [
+    { icon: "📧", label: t.contact.emailLabel, value: "contact@glevosys.com" },
+    { icon: "📱", label: t.contact.phoneLabel, value: "+237 6XX XXX XXX" },
+    { icon: "📍", label: t.contact.locationLabel, value: "Yaoundé, Cameroun" },
+  ];
+
   return (
     <section
       id="contact"
@@ -139,7 +147,7 @@ const Contact = () => {
                 }}
               />
               <span className="text-sm font-semibold text-blue-700">
-                Contactez-nous
+                {t.contact.badge}
               </span>
             </motion.div>
             <motion.h2
@@ -148,7 +156,7 @@ const Contact = () => {
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
               transition={{ duration: 0.8, delay: 0.2 }}
             >
-              {`Contactez-nous `.split(" ").map((word, index) => (
+              {t.contact.headingStart.split(" ").map((word, index) => (
                 <motion.span
                   key={index}
                   className="inline-block mr-2"
@@ -158,15 +166,10 @@ const Contact = () => {
                   }
                   transition={{ delay: 0.3 + index * 0.05, duration: 0.5 }}
                 >
-                  {word === "maintenant" ? (
-                    <span className="font-bold">{word}</span>
-                  ) : (
-                    word
-                  )}
+                  {word}
                 </motion.span>
               ))}
-              pour discuter de vos besoins en transformation numérique et
-              découvrir comment{" "}
+              {t.contact.headingMiddle}
               <motion.span
                 className="text-[#0015CC] font-semibold inline-block"
                 animate={{
@@ -180,7 +183,7 @@ const Contact = () => {
               >
                 Glevosys
               </motion.span>{" "}
-              peut vous accompagner.
+              {t.contact.headingEnd}
             </motion.h2>
             <motion.div
               className="h-1 w-32 bg-gradient-to-r from-blue-600 via-purple-600 to-transparent rounded-full mx-auto lg:mx-0"
@@ -196,15 +199,7 @@ const Contact = () => {
               animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
               transition={{ delay: 0.8, duration: 0.6 }}
             >
-              {[
-                { icon: "📧", label: "Email", value: "contact@glevosys.com" },
-                { icon: "📱", label: "Téléphone", value: "+237 6XX XXX XXX" },
-                {
-                  icon: "📍",
-                  label: "Localisation",
-                  value: "Yaoundé, Cameroun",
-                },
-              ].map((item, index) => (
+              {contactItems.map((item, index) => (
                 <motion.div
                   key={index}
                   className="flex items-center gap-3 text-gray-600"
@@ -240,11 +235,12 @@ const Contact = () => {
                 className="flex flex-col gap-2"
               >
                 <label className="text-sm md:text-base font-bold text-gray-900">
-                  Votre nom<span className="text-red-500">*</span>
+                  {t.contact.form.nameLabel}
+                  <span className="text-red-500">*</span>
                 </label>
                 <motion.input
                   type="text"
-                  placeholder="Insérer votre nom complet"
+                  placeholder={t.contact.form.namePlaceholder}
                   name="nom"
                   className="w-full px-5 py-3 rounded-full border border-gray-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all placeholder:text-gray-400 text-sm md:text-base"
                   required
@@ -257,12 +253,13 @@ const Contact = () => {
                 className="flex flex-col gap-2"
               >
                 <label className="text-sm md:text-base font-bold text-gray-900">
-                  Votre entreprise<span className="text-red-500">*</span>
+                  {t.contact.form.companyLabel}
+                  <span className="text-red-500">*</span>
                 </label>
                 <motion.input
                   type="text"
                   name="entreprise"
-                  placeholder="Orange, MTN, ..."
+                  placeholder={t.contact.form.companyPlaceholder}
                   className="w-full px-5 py-3 rounded-full border border-gray-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all placeholder:text-gray-400 text-sm md:text-base"
                   required
                   whileFocus={{ scale: 1.02 }}
@@ -272,7 +269,8 @@ const Contact = () => {
             </motion.div>
             <motion.div variants={itemVariants} className="flex flex-col gap-2">
               <label className="text-sm md:text-base font-bold text-gray-900">
-                Votre Email<span className="text-red-500">*</span>
+                {t.contact.form.emailLabel}
+                <span className="text-red-500">*</span>
               </label>
               <motion.input
                 type="email"
@@ -286,7 +284,7 @@ const Contact = () => {
             </motion.div>
             <motion.div variants={itemVariants} className="flex flex-col gap-2">
               <label className="text-sm md:text-base font-bold text-gray-900">
-                Sur quoi souhaitez-vous travailler en priorité ?
+                {t.contact.form.serviceLabel}
                 <span className="text-red-500">*</span>
               </label>
               <div className="relative group">
@@ -299,11 +297,11 @@ const Contact = () => {
                   transition={{ duration: 0.2 }}
                 >
                   <option value="" className="text-gray-200">
-                    Veillez renseigner le service en particulier
+                    {t.contact.form.servicePlaceholder}
                   </option>
-                  <option value="web">Développement Web/App</option>
-                  <option value="ia">Intelligence artificielle</option>
-                  <option value="secu">Sécurité informatique</option>
+                  <option value="web">{t.contact.form.serviceWeb}</option>
+                  <option value="ia">{t.contact.form.serviceAI}</option>
+                  <option value="secu">{t.contact.form.serviceSecurity}</option>
                 </motion.select>
                 <motion.div
                   className="absolute right-6 top-1/2 -translate-y-1/2 pointer-events-none text-white"
@@ -332,13 +330,15 @@ const Contact = () => {
             </motion.div>
             <motion.div variants={itemVariants} className="flex flex-col gap-2">
               <label className="text-sm md:text-base font-bold text-gray-900">
-                Un mot pour nous en dire plus ?{" "}
-                <span className="font-normal text-gray-500">(optionnel)</span>
+                {t.contact.form.messageLabel}{" "}
+                <span className="font-normal text-gray-500">
+                  {t.contact.form.messageOptional}
+                </span>
               </label>
               <motion.textarea
                 rows={4}
                 name="message"
-                placeholder="Décrivez brièvement votre contexte ou votre idée..."
+                placeholder={t.contact.form.messagePlaceholder}
                 className="w-full px-6 py-4 rounded-2xl md:rounded-3xl border border-gray-300 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all placeholder:text-gray-400 resize-none text-sm md:text-base"
                 whileFocus={{ scale: 1.01 }}
                 transition={{ duration: 0.2 }}
@@ -362,7 +362,7 @@ const Contact = () => {
                   className="relative z-10 flex items-center justify-center gap-2"
                   initial={{ x: 0 }}
                 >
-                  Entrer en contact
+                  {t.contact.form.submit}
                   <motion.span
                     animate={{ x: [0, 5, 0] }}
                     transition={{

--- a/src/components/Domain/index.tsx
+++ b/src/components/Domain/index.tsx
@@ -2,8 +2,20 @@ import { motion } from "framer-motion";
 import { useInView } from "framer-motion";
 import { useRef } from "react";
 import images from "../../assets/pictures";
+import { useLanguage } from "../../i18n/LanguageContext";
+
+const domainImages = [images.d1, images.d2, images.d3];
+const imagePositions = [
+  "bottom-right",
+  "bottom-full",
+  "bottom-full-tall",
+] as const;
+const bgColors = ["bg-[#E8ECF1]", "bg-[#E8ECF1]", "bg-[#E8ECF1]"];
+const delays = [0.2, 0.4, 0.6];
+const isFullHeights = [false, false, true];
 
 const Domain = () => {
+  const { t } = useLanguage();
   const titleRef = useRef(null);
   const isTitleInView = useInView(titleRef, { once: true, amount: 0.5 });
 
@@ -95,7 +107,7 @@ const Domain = () => {
               }}
             />
             <span className="text-sm font-semibold text-blue-700">
-              Nos expertises
+              {t.domain.badge}
             </span>
           </motion.div>
           <motion.h2
@@ -114,7 +126,7 @@ const Domain = () => {
               }}
               style={{ backgroundSize: "200% 200%" }}
             >
-              Nos domaines d'activité
+              {t.domain.title}
             </motion.span>
           </motion.h2>
           <motion.div
@@ -131,52 +143,40 @@ const Domain = () => {
             variants={subtitleVariants}
             className="text-base md:text-lg text-gray-600 max-w-2xl mx-auto"
           >
-            Une expertise complète pour répondre à tous vos besoins numériques.
+            {t.domain.subtitle}
           </motion.p>
         </motion.div>
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 max-w-7xl mx-auto">
           <div className="lg:col-span-7 flex flex-col gap-6">
             <DomainCard
-              delay={0.2}
-              title="Consulting & Dev/DevSecOps"
-              description="Audit, intégration, migration vers GitHub / Azure / CI-CD."
-              tags={[
-                "Audit Dev/DevSecOps",
-                "Migration Cloud",
-                "Sécurisation CI/CD",
-              ]}
-              image={images.d1}
-              imagePosition="bottom-right"
-              bgColor="bg-[#E8ECF1]"
+              delay={delays[0]}
+              title={t.domain.cards[0].title}
+              description={t.domain.cards[0].description}
+              tags={t.domain.cards[0].tags}
+              image={domainImages[0]}
+              imagePosition={imagePositions[0]}
+              bgColor={bgColors[0]}
             />
             <DomainCard
-              delay={0.4}
-              title="Développement & Intégration"
-              description="Conception d'applications et agents IA internes."
-              tags={[
-                "Outils internes",
-                "Agent ChatGPT",
-                "Copilot personnalisé",
-              ]}
-              image={images.d2}
-              imagePosition="bottom-full"
-              bgColor="bg-[#E8ECF1]"
+              delay={delays[1]}
+              title={t.domain.cards[1].title}
+              description={t.domain.cards[1].description}
+              tags={t.domain.cards[1].tags}
+              image={domainImages[1]}
+              imagePosition={imagePositions[1]}
+              bgColor={bgColors[1]}
             />
           </div>
           <div className="lg:col-span-5">
             <DomainCard
-              delay={0.6}
-              title="Formation & Acculturation IA"
-              description="Formations corporate sur DevOps appliquée au développement."
-              tags={[
-                "Workshops IA + Dev",
-                "Formation équipes",
-                "Coaching technique",
-              ]}
-              image={images.d3}
-              imagePosition="bottom-full-tall"
-              bgColor="bg-[#E8ECF1]"
-              isFullHeight
+              delay={delays[2]}
+              title={t.domain.cards[2].title}
+              description={t.domain.cards[2].description}
+              tags={t.domain.cards[2].tags}
+              image={domainImages[2]}
+              imagePosition={imagePositions[2]}
+              bgColor={bgColors[2]}
+              isFullHeight={isFullHeights[2]}
             />
           </div>
         </div>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,7 +1,10 @@
 import images from "../../assets/pictures";
-import { Instagram, Linkedin, Twitter } from "lucide-react"; // Optionnel : installe lucide-react
+import { Instagram, Linkedin, Twitter } from "lucide-react";
+import { useLanguage } from "../../i18n/LanguageContext";
 
 const Footer = () => {
+  const { t } = useLanguage();
+
   return (
     <footer className="bg-[#050B44] py-16 text-white/80">
       <div className="container mx-auto px-6 lg:px-12">
@@ -14,11 +17,10 @@ const Footer = () => {
             />
             <div className="space-y-4">
               <p className="text-lg font-medium text-white/60">
-                Du code à la croissance.
+                {t.footer.tagline}
               </p>
               <p className="max-w-sm leading-relaxed text-white/50">
-                Accompagner les entreprises africaines dans leur transformation
-                numérique par l'intégration de solutions cloud et IA.
+                {t.footer.description}
               </p>
             </div>
             <div className="flex space-x-5 pt-4">
@@ -28,15 +30,11 @@ const Footer = () => {
             </div>
           </div>
           <div className="lg:col-span-4 lg:pl-10">
-            <h4 className="mb-6 text-xl font-semibold text-white">Solutions</h4>
+            <h4 className="mb-6 text-xl font-semibold text-white">
+              {t.footer.solutionsTitle}
+            </h4>
             <ul className="space-y-3">
-              {[
-                "Développement Web & App",
-                "Architecture réseaux & cloud",
-                "Sécurité informatique",
-                "Intelligence artificielle",
-                "Formation",
-              ].map((item) => (
+              {t.footer.solutions.map((item) => (
                 <li
                   key={item}
                   className="cursor-pointer hover:text-white transition-colors"
@@ -47,7 +45,9 @@ const Footer = () => {
             </ul>
           </div>
           <div className="lg:col-span-3">
-            <h4 className="mb-6 text-xl font-semibold text-white">Contact</h4>
+            <h4 className="mb-6 text-xl font-semibold text-white">
+              {t.footer.contactTitle}
+            </h4>
             <ul className="space-y-3">
               <li className="cursor-pointer hover:text-white transition-colors text-white/70">
                 www.glevosys.com

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,24 +2,21 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { FiMenu, FiX } from "react-icons/fi";
 import images from "../../assets/pictures";
-
-type NavType = {
-  title: string;
-  path: string;
-  id: string;
-};
-
-const navs: NavType[] = [
-  { title: "Nos solutions", path: "#solution", id: "solution" },
-  { title: "Mission", path: "#mission", id: "mission" },
-  { title: "Domaine", path: "#domaine", id: "domaine" },
-  { title: "Contact", path: "#contact", id: "contact" },
-];
+import { useLanguage } from "../../i18n/LanguageContext";
+import type { Language } from "../../i18n/LanguageContext";
 
 const Header = () => {
+  const { language, setLanguage, t } = useLanguage();
   const [open, setOpen] = useState(false);
   const [activeSection] = useState("");
   const [scrolled, setScrolled] = useState(false);
+
+  const navs = [
+    { title: t.nav.solutions, path: "#solution", id: "solution" },
+    { title: t.nav.mission, path: "#mission", id: "mission" },
+    { title: t.nav.domain, path: "#domaine", id: "domaine" },
+    { title: t.nav.contact, path: "#contact", id: "contact" },
+  ];
 
   useEffect(() => {
     const handleScroll = () => {
@@ -124,6 +121,8 @@ const Header = () => {
     },
   };
 
+  const langs: Language[] = ["fr", "en"];
+
   return (
     <motion.header
       className={`sticky top-0 z-[100] bg-white transition-all duration-300 ${
@@ -186,6 +185,23 @@ const Header = () => {
             ))}
           </ul>
         </nav>
+        <div className="hidden md:flex items-center gap-1 bg-gray-100 rounded-full p-1">
+          {langs.map((lang) => (
+            <motion.button
+              key={lang}
+              onClick={() => setLanguage(lang)}
+              className={`px-3 py-1 rounded-full text-sm font-bold transition-colors ${
+                language === lang
+                  ? "bg-[#0015CC] text-white"
+                  : "text-gray-500 hover:text-gray-900"
+              }`}
+              whileTap={{ scale: 0.95 }}
+              transition={{ duration: 0.2 }}
+            >
+              {lang.toUpperCase()}
+            </motion.button>
+          ))}
+        </div>
         <motion.button
           onClick={() => setOpen(!open)}
           className="md:hidden relative z-[150] text-3xl text-gray-900"
@@ -283,6 +299,26 @@ const Header = () => {
                   ))}
                 </ul>
                 <motion.div
+                  className="mt-6 flex items-center gap-1 bg-gray-100 rounded-full p-1 w-fit"
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.7 }}
+                >
+                  {langs.map((lang) => (
+                    <button
+                      key={lang}
+                      onClick={() => setLanguage(lang)}
+                      className={`px-3 py-1 rounded-full text-sm font-bold transition-colors ${
+                        language === lang
+                          ? "bg-[#0015CC] text-white"
+                          : "text-gray-500 hover:text-gray-900"
+                      }`}
+                    >
+                      {lang.toUpperCase()}
+                    </button>
+                  ))}
+                </motion.div>
+                <motion.div
                   className="mt-auto border-t border-gray-100 pt-8"
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -294,7 +330,7 @@ const Header = () => {
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 0.9 }}
                   >
-                    Du code à la croissance.
+                    {t.header.tagline}
                   </motion.p>
                   <motion.p
                     className="text-gray-400 text-sm"
@@ -302,7 +338,7 @@ const Header = () => {
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 1 }}
                   >
-                    © 2026 Glevosys
+                    {t.header.copyright}
                   </motion.p>
                 </motion.div>
               </div>

--- a/src/components/Innovation/index.tsx
+++ b/src/components/Innovation/index.tsx
@@ -1,34 +1,21 @@
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import images from "../../assets/pictures";
+import { useLanguage } from "../../i18n/LanguageContext";
 
-const slides = [
-  {
-    id: 1,
-    title: "Innovation pragmatique",
-    description:
-      "Nous intégrons l'IA et l'automatisation là où elles apportent un réel impact business.",
-    image: images.c1,
-  },
-  {
-    id: 2,
-    title: "Expertise Technique",
-    description:
-      "Des solutions sur mesure pour répondre à vos défis technologiques les plus complexes.",
-    image: images.c2,
-  },
-  {
-    id: 3,
-    title: "Impact Business",
-    description:
-      "Prioriser la valeur métier pour garantir un retour sur investissement rapide.",
-    image: images.c3,
-  },
-];
+const slideImages = [images.c1, images.c2, images.c3];
 
 const Innovation = () => {
+  const { t } = useLanguage();
   const [current, setCurrent] = useState(0);
   const [direction, setDirection] = useState(0);
+
+  const slides = t.innovation.slides.map((slide, i) => ({
+    id: i + 1,
+    title: slide.title,
+    description: slide.description,
+    image: slideImages[i],
+  }));
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -36,7 +23,7 @@ const Innovation = () => {
       setCurrent((prev) => (prev === slides.length - 1 ? 0 : prev + 1));
     }, 7000);
     return () => clearInterval(timer);
-  }, []);
+  }, [slides.length]);
 
   const handleSlideChange = (index: number) => {
     setDirection(index > current ? 1 : -1);
@@ -174,7 +161,7 @@ const Innovation = () => {
                 </span>
                 <div className="h-12 w-0.5 bg-white/30" />
                 <span className="text-sm font-semibold uppercase tracking-wider text-white/60">
-                  {slides[current].id} de {slides.length}
+                  {slides[current].id} {t.innovation.of} {slides.length}
                 </span>
               </motion.div>
 
@@ -238,7 +225,7 @@ const Innovation = () => {
                 className="group relative rounded-full border-2 border-white/40 bg-white/10 px-8 py-3.5 font-semibold backdrop-blur-sm transition-all overflow-hidden"
               >
                 <span className="relative z-10 flex items-center gap-2">
-                  Parler à un expert
+                  {t.innovation.cta}
                   <motion.span
                     className="inline-block"
                     animate={{ x: [0, 5, 0] }}

--- a/src/components/Intro/index.tsx
+++ b/src/components/Intro/index.tsx
@@ -1,7 +1,10 @@
 import { motion } from "framer-motion";
 import { Button } from "../ui/Button";
+import { useLanguage } from "../../i18n/LanguageContext";
 
 const Intro = () => {
+  const { t } = useLanguage();
+
   const containerVariants = {
     hidden: { opacity: 0 },
     visible: {
@@ -127,16 +130,16 @@ const Intro = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
             >
-              Du code à la{" "}
+              {t.intro.title1}{" "}
             </motion.span>
             <br className="hidden md:block" />
             <motion.span
-              className="inline-block bg-gradient-to-r from-blue-600 via-blue-700 to-purple-600 bg-clip-text text-transparent"
+              className="inline-block bg-gradient-to-r from-blue-600 via-blue-700 to-purple-600 bg-clip-text text-transparent pb-4"
               initial={{ opacity: 0, y: 50 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.4 }}
             >
-              croissance
+              {t.intro.title2}
             </motion.span>
             <motion.div
               className="mx-auto mt-4 h-1 w-32 rounded-full bg-gradient-to-r from-blue-600 to-purple-600"
@@ -149,10 +152,7 @@ const Intro = () => {
             className="mt-6 max-w-2xl text-center text-lg leading-relaxed text-gray-600 md:text-xl"
             variants={itemVariants}
           >
-            Glevosys accompagne les entreprises africaines dans leur
-            transformation numérique par l'intégration des solutions cloud et
-            IA, le développement d'agents logiciels et la montée en compétence
-            des équipes.
+            {t.intro.description}
           </motion.p>
           <motion.div
             className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:gap-6"
@@ -166,7 +166,7 @@ const Intro = () => {
             >
               <Button className="h-14 rounded-full bg-blue-700 px-10 text-lg font-medium hover:bg-blue-800 transition-all shadow-lg shadow-blue-700/30 hover:shadow-xl hover:shadow-blue-700/40 group">
                 <span className="flex items-center gap-2">
-                  Parler à un expert
+                  {t.intro.ctaExpert}
                   <motion.span
                     className="inline-block"
                     animate={{ x: [0, 5, 0] }}
@@ -191,7 +191,7 @@ const Intro = () => {
                 variant="secondary"
                 className="h-14 rounded-full border-gray-200 bg-white px-10 text-lg font-medium text-black hover:bg-gray-50 transition-all shadow-md hover:shadow-lg"
               >
-                Découvrir nos solutions
+                {t.intro.ctaSolutions}
               </Button>
             </motion.a>
           </motion.div>
@@ -211,7 +211,7 @@ const Intro = () => {
               }}
             >
               <span className="text-xs font-medium uppercase tracking-wider">
-                Scroll
+                {t.intro.scroll}
               </span>
               <svg
                 className="w-6 h-6"

--- a/src/components/Mission/index.tsx
+++ b/src/components/Mission/index.tsx
@@ -1,7 +1,10 @@
 import { motion } from "framer-motion";
 import images from "../../assets/pictures";
+import { useLanguage } from "../../i18n/LanguageContext";
 
 const Mission = () => {
+  const { t } = useLanguage();
+
   const flags = [
     images.bf,
     images.cm,
@@ -100,7 +103,7 @@ const Mission = () => {
                 viewport={{ once: true }}
                 transition={{ delay: 0.2, duration: 0.6 }}
               >
-                Accompagner
+                {t.mission.line1}
               </motion.span>
               <motion.span
                 className="block text-[#0015CC] bg-gradient-to-r from-[#0015CC] to-[#0033FF] bg-clip-text text-transparent"
@@ -109,7 +112,7 @@ const Mission = () => {
                 viewport={{ once: true }}
                 transition={{ delay: 0.4, duration: 0.6 }}
               >
-                +300 Entreprises africaines
+                {t.mission.line2}
               </motion.span>
               <motion.span
                 className="block mt-2 text-gray-700"
@@ -118,7 +121,7 @@ const Mission = () => {
                 viewport={{ once: true }}
                 transition={{ delay: 0.6, duration: 0.6 }}
               >
-                dans leur transformation numérique
+                {t.mission.line3}
               </motion.span>
             </h2>
 
@@ -209,7 +212,7 @@ const Mission = () => {
                   viewport={{ once: true }}
                   transition={{ delay: 0.5, duration: 0.6 }}
                 >
-                  Entreprises
+                  {t.mission.companies}
                 </motion.span>
 
                 {/* Decorative elements */}

--- a/src/components/OurSolution/index.tsx
+++ b/src/components/OurSolution/index.tsx
@@ -2,6 +2,16 @@ import { motion } from "framer-motion";
 import { useInView } from "framer-motion";
 import { useRef } from "react";
 import images from "../../assets/pictures";
+import { useLanguage } from "../../i18n/LanguageContext";
+
+const cardImages = [
+  images.c1,
+  images.c2,
+  images.c3,
+  images.c4,
+  images.c5,
+  images.c6,
+];
 
 type CardSolutionProps = {
   picture: string;
@@ -9,6 +19,7 @@ type CardSolutionProps = {
   content?: string[];
   link?: string;
   index: number;
+  cta: string;
 };
 
 const CardSolution = ({
@@ -17,6 +28,7 @@ const CardSolution = ({
   content,
   link,
   index,
+  cta,
 }: CardSolutionProps) => {
   const cardRef = useRef(null);
   const isInView = useInView(cardRef, { once: true, amount: 0.2 });
@@ -160,7 +172,7 @@ const CardSolution = ({
               transition={{ duration: 0.3 }}
             >
               <span className="relative">
-                Parler à un expert
+                {cta}
                 <motion.span
                   className="absolute bottom-0 left-0 h-0.5 bg-blue-600"
                   initial={{ width: 0 }}
@@ -212,6 +224,7 @@ const CardSolution = ({
 };
 
 const OurSolution = () => {
+  const { t } = useLanguage();
   const titleRef = useRef(null);
   const isTitleInView = useInView(titleRef, { once: true, amount: 0.5 });
 
@@ -299,7 +312,7 @@ const OurSolution = () => {
               }}
             />
             <span className="text-sm font-semibold text-blue-700">
-              Ce que nous offrons
+              {t.solution.badge}
             </span>
           </motion.div>
 
@@ -320,7 +333,7 @@ const OurSolution = () => {
               }}
               style={{ backgroundSize: "200% 200%" }}
             >
-              Nos solutions
+              {t.solution.title}
             </motion.span>
           </motion.h2>
           <motion.div
@@ -337,67 +350,21 @@ const OurSolution = () => {
             variants={subtitleVariants}
             className="text-lg lg:text-xl text-gray-600 max-w-3xl mx-auto mt-6"
           >
-            Des solutions complètes pour accompagner votre transformation
-            numérique
+            {t.solution.subtitle}
           </motion.p>
         </motion.div>
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-2 gap-10 max-w-7xl mx-auto">
-          <CardSolution
-            index={0}
-            title="Développement Web/App"
-            picture={images.c1}
-            content={[
-              "Applications métiers sur mesure",
-              "Plateformes web et mobiles scalables",
-              "Intégration API et systèmes existants",
-            ]}
-            link="#"
-          />
-          <CardSolution
-            index={1}
-            title="Architecture réseau"
-            picture={images.c2}
-            content={[
-              "Conception d'architectures cloud hybrides",
-              "Migration vers le cloud",
-              "Optimisation des performances et de la disponibilité",
-            ]}
-            link="#"
-          />
-          <CardSolution
-            index={2}
-            title="Sécurité informatique"
-            picture={images.c3}
-            content={[
-              "Audit et renforcement des systèmes",
-              "Sécurisation des réseaux et des données",
-              "Bonnes pratiques et conformité",
-            ]}
-            link="#"
-          />
-          <CardSolution
-            index={3}
-            title="Intelligence artificielle & agents IA"
-            picture={images.c4}
-            content={[
-              "Agents IA pour automatisation des processus",
-              "Analyse de données et aide à la décision",
-              "IA appliquée aux métiers (support, opérations,...)",
-            ]}
-            link="#"
-          />
-          <CardSolution
-            index={4}
-            title="Formation & montée en compétences"
-            picture={images.c5}
-            content={[
-              "Formations techniques pour équipes IT",
-              "Sensibilisation à la cybersécurité et à l'IA",
-              "Accompagnement à long terme",
-            ]}
-            link="#"
-          />
-          <CardSolution index={5} title="Et bien plus..." picture={images.c6} />
+          {t.solution.cards.map((card, index) => (
+            <CardSolution
+              key={index}
+              index={index}
+              title={card.title}
+              picture={cardImages[index]}
+              content={card.content}
+              link={card.content ? "#" : undefined}
+              cta={t.solution.cta}
+            />
+          ))}
         </div>
       </div>
     </section>

--- a/src/i18n/LanguageContext.tsx
+++ b/src/i18n/LanguageContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState } from "react";
+import type { ReactNode } from "react";
+import fr from "./translations/fr";
+import en from "./translations/en";
+
+export type Language = "fr" | "en";
+type Translations = typeof fr;
+
+interface LanguageContextType {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: Translations;
+}
+
+const LanguageContext = createContext<LanguageContextType | null>(null);
+
+export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguage] = useState<Language>("fr");
+  const t = language === "fr" ? fr : en;
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error("useLanguage must be used inside LanguageProvider");
+  return ctx;
+};

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -1,0 +1,171 @@
+const en = {
+  nav: {
+    solutions: "Our solutions",
+    mission: "Mission",
+    domain: "Domain",
+    contact: "Contact",
+  },
+  header: {
+    tagline: "From code to growth.",
+    copyright: "© 2026 Glevosys",
+  },
+  intro: {
+    title1: "From code to",
+    title2: "growth",
+    description:
+      "Glevosys supports African companies in their digital transformation through the integration of cloud and AI solutions, the development of software agents and the upskilling of teams.",
+    ctaExpert: "Talk to an expert",
+    ctaSolutions: "Discover our solutions",
+    scroll: "Scroll",
+  },
+  innovation: {
+    slides: [
+      {
+        title: "Pragmatic Innovation",
+        description:
+          "We integrate AI and automation where they deliver real business impact.",
+      },
+      {
+        title: "Technical Expertise",
+        description:
+          "Tailored solutions to address your most complex technological challenges.",
+      },
+      {
+        title: "Business Impact",
+        description:
+          "Prioritizing business value to ensure a fast return on investment.",
+      },
+    ],
+    of: "of",
+    cta: "Talk to an expert",
+  },
+  about: {
+    badge: "Glevosys",
+    heading: "Who are we?",
+    description:
+      "GlevoSys is a technology company specializing in the digital transformation of large African organizations. Inspired by the legacy of the continent's visionary leaders, our mission is to design, integrate and secure high-value digital solutions, spanning cloud and artificial intelligence to application development and cybersecurity. We support companies in modernizing their systems, optimizing their performance and upskilling their teams.",
+    toolsTagline: "We choose tools based on your challenges,",
+    toolsEmphasis: "not the other way around.",
+  },
+  solution: {
+    badge: "What we offer",
+    title: "Our solutions",
+    subtitle: "Complete solutions to support your digital transformation",
+    cta: "Talk to an expert",
+    cards: [
+      {
+        title: "Web/App Development",
+        content: [
+          "Custom business applications",
+          "Scalable web and mobile platforms",
+          "API and existing systems integration",
+        ],
+      },
+      {
+        title: "Network Architecture",
+        content: [
+          "Hybrid cloud architecture design",
+          "Cloud migration",
+          "Performance and availability optimization",
+        ],
+      },
+      {
+        title: "Cybersecurity",
+        content: [
+          "System audit and hardening",
+          "Network and data security",
+          "Best practices and compliance",
+        ],
+      },
+      {
+        title: "Artificial intelligence & AI agents",
+        content: [
+          "AI agents for process automation",
+          "Data analysis and decision support",
+          "AI applied to business (support, operations,...)",
+        ],
+      },
+      {
+        title: "Training & upskilling",
+        content: [
+          "Technical training for IT teams",
+          "Cybersecurity and AI awareness",
+          "Long-term support",
+        ],
+      },
+      {
+        title: "And much more...",
+      },
+    ],
+  },
+  mission: {
+    line1: "Supporting",
+    line2: "+300 African companies",
+    line3: "in their digital transformation",
+    companies: "Companies",
+  },
+  domain: {
+    badge: "Our expertise",
+    title: "Our areas of activity",
+    subtitle: "Complete expertise to meet all your digital needs.",
+    cards: [
+      {
+        title: "Consulting & Dev/DevSecOps",
+        description: "Audit, integration, migration to GitHub / Azure / CI-CD.",
+        tags: ["Dev/DevSecOps Audit", "Cloud Migration", "CI/CD Security"],
+      },
+      {
+        title: "Development & Integration",
+        description: "Design of internal applications and AI agents.",
+        tags: ["Internal tools", "ChatGPT Agent", "Custom Copilot"],
+      },
+      {
+        title: "AI Training & Acculturation",
+        description: "Corporate training on DevOps applied to development.",
+        tags: ["AI + Dev Workshops", "Team Training", "Technical Coaching"],
+      },
+    ],
+  },
+  contact: {
+    badge: "Contact us",
+    headingStart: "Contact us ",
+    headingMiddle:
+      "to discuss your digital transformation needs and discover how ",
+    headingEnd: "can support you.",
+    emailLabel: "Email",
+    phoneLabel: "Phone",
+    locationLabel: "Location",
+    form: {
+      nameLabel: "Your name",
+      namePlaceholder: "Enter your full name",
+      companyLabel: "Your company",
+      companyPlaceholder: "Orange, MTN, ...",
+      emailLabel: "Your Email",
+      serviceLabel: "What do you want to work on first?",
+      servicePlaceholder: "Please select a service",
+      serviceWeb: "Web/App Development",
+      serviceAI: "Artificial Intelligence",
+      serviceSecurity: "Cybersecurity",
+      messageLabel: "A word to tell us more?",
+      messageOptional: "(optional)",
+      messagePlaceholder: "Briefly describe your context or idea...",
+      submit: "Get in touch",
+    },
+  },
+  footer: {
+    tagline: "From code to growth.",
+    description:
+      "Supporting African companies in their digital transformation through cloud and AI solutions integration.",
+    solutionsTitle: "Solutions",
+    solutions: [
+      "Web & App Development",
+      "Network & Cloud Architecture",
+      "Cybersecurity",
+      "Artificial Intelligence",
+      "Training",
+    ],
+    contactTitle: "Contact",
+  },
+};
+
+export default en;

--- a/src/i18n/translations/fr.ts
+++ b/src/i18n/translations/fr.ts
@@ -1,0 +1,174 @@
+const fr = {
+  nav: {
+    solutions: "Nos solutions",
+    mission: "Mission",
+    domain: "Domaine",
+    contact: "Contact",
+  },
+  header: {
+    tagline: "Du code à la croissance.",
+    copyright: "© 2026 Glevosys",
+  },
+  intro: {
+    title1: "Du code à la",
+    title2: "croissance",
+    description:
+      "Glevosys accompagne les entreprises africaines dans leur transformation numérique par l'intégration des solutions cloud et IA, le développement d'agents logiciels et la montée en compétence des équipes.",
+    ctaExpert: "Parler à un expert",
+    ctaSolutions: "Découvrir nos solutions",
+    scroll: "Scroll",
+  },
+  innovation: {
+    slides: [
+      {
+        title: "Innovation pragmatique",
+        description:
+          "Nous intégrons l'IA et l'automatisation là où elles apportent un réel impact business.",
+      },
+      {
+        title: "Expertise Technique",
+        description:
+          "Des solutions sur mesure pour répondre à vos défis technologiques les plus complexes.",
+      },
+      {
+        title: "Impact Business",
+        description:
+          "Prioriser la valeur métier pour garantir un retour sur investissement rapide.",
+      },
+    ],
+    of: "de",
+    cta: "Parler à un expert",
+  },
+  about: {
+    badge: "Glevosys",
+    heading: "Qui sommes-nous ?",
+    description:
+      "GlevoSys est une entreprise technologique spécialisée dans la transformation numérique des grandes organisations africaines. Inspirée par l'héritage des leaders visionnaires du continent, notre mission est de concevoir, intégrer et sécuriser des solutions numériques à forte valeur ajoutée, allant du cloud et de l'intelligence artificielle au développement d'applications et à la cybersécurité. Nous accompagnons les entreprises dans la modernisation de leurs systèmes, l'optimisation de leurs performances et la montée en compétences de leurs équipes.",
+    toolsTagline: "Nous choisissons des outils en fonction de vos enjeux,",
+    toolsEmphasis: "pas l'inverse.",
+  },
+  solution: {
+    badge: "Ce que nous offrons",
+    title: "Nos solutions",
+    subtitle:
+      "Des solutions complètes pour accompagner votre transformation numérique",
+    cta: "Parler à un expert",
+    cards: [
+      {
+        title: "Développement Web/App",
+        content: [
+          "Applications métiers sur mesure",
+          "Plateformes web et mobiles scalables",
+          "Intégration API et systèmes existants",
+        ],
+      },
+      {
+        title: "Architecture réseau",
+        content: [
+          "Conception d'architectures cloud hybrides",
+          "Migration vers le cloud",
+          "Optimisation des performances et de la disponibilité",
+        ],
+      },
+      {
+        title: "Sécurité informatique",
+        content: [
+          "Audit et renforcement des systèmes",
+          "Sécurisation des réseaux et des données",
+          "Bonnes pratiques et conformité",
+        ],
+      },
+      {
+        title: "Intelligence artificielle & agents IA",
+        content: [
+          "Agents IA pour automatisation des processus",
+          "Analyse de données et aide à la décision",
+          "IA appliquée aux métiers (support, opérations,...)",
+        ],
+      },
+      {
+        title: "Formation & montée en compétences",
+        content: [
+          "Formations techniques pour équipes IT",
+          "Sensibilisation à la cybersécurité et à l'IA",
+          "Accompagnement à long terme",
+        ],
+      },
+      {
+        title: "Et bien plus...",
+      },
+    ],
+  },
+  mission: {
+    line1: "Accompagner",
+    line2: "+300 Entreprises africaines",
+    line3: "dans leur transformation numérique",
+    companies: "Entreprises",
+  },
+  domain: {
+    badge: "Nos expertises",
+    title: "Nos domaines d'activité",
+    subtitle:
+      "Une expertise complète pour répondre à tous vos besoins numériques.",
+    cards: [
+      {
+        title: "Consulting & Dev/DevSecOps",
+        description: "Audit, intégration, migration vers GitHub / Azure / CI-CD.",
+        tags: ["Audit Dev/DevSecOps", "Migration Cloud", "Sécurisation CI/CD"],
+      },
+      {
+        title: "Développement & Intégration",
+        description: "Conception d'applications et agents IA internes.",
+        tags: ["Outils internes", "Agent ChatGPT", "Copilot personnalisé"],
+      },
+      {
+        title: "Formation & Acculturation IA",
+        description:
+          "Formations corporate sur DevOps appliquée au développement.",
+        tags: ["Workshops IA + Dev", "Formation équipes", "Coaching technique"],
+      },
+    ],
+  },
+  contact: {
+    badge: "Contactez-nous",
+    headingStart: "Contactez-nous ",
+    headingMiddle:
+      "pour discuter de vos besoins en transformation numérique et découvrir comment ",
+    headingEnd: "peut vous accompagner.",
+    emailLabel: "Email",
+    phoneLabel: "Téléphone",
+    locationLabel: "Localisation",
+    form: {
+      nameLabel: "Votre nom",
+      namePlaceholder: "Insérer votre nom complet",
+      companyLabel: "Votre entreprise",
+      companyPlaceholder: "Orange, MTN, ...",
+      emailLabel: "Votre Email",
+      serviceLabel: "Sur quoi souhaitez-vous travailler en priorité ?",
+      servicePlaceholder: "Veillez renseigner le service en particulier",
+      serviceWeb: "Développement Web/App",
+      serviceAI: "Intelligence artificielle",
+      serviceSecurity: "Sécurité informatique",
+      messageLabel: "Un mot pour nous en dire plus ?",
+      messageOptional: "(optionnel)",
+      messagePlaceholder: "Décrivez brièvement votre contexte ou votre idée...",
+      submit: "Entrer en contact",
+    },
+  },
+  footer: {
+    tagline: "Du code à la croissance.",
+    description:
+      "Accompagner les entreprises africaines dans leur transformation numérique par l'intégration de solutions cloud et IA.",
+    solutionsTitle: "Solutions",
+    solutions: [
+      "Développement Web & App",
+      "Architecture réseaux & cloud",
+      "Sécurité informatique",
+      "Intelligence artificielle",
+      "Formation",
+    ],
+    contactTitle: "Contact",
+  },
+};
+
+export default fr;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router-dom";
+import { LanguageProvider } from "./i18n/LanguageContext";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <LanguageProvider>
+        <App />
+      </LanguageProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary

- Add a `LanguageContext` with `useLanguage` hook (no extra dependencies)
- Add French and English translation files under `src/i18n/translations/`
- Update all 9 components to use translations (Header, Intro, Innovation, AboutUS, OurSolution, Mission, Domain, Contact, Footer)
- Add a FR/EN toggle pill button in the Header (visible on both desktop and mobile)

## Test plan

- [ ] Visit the site and verify all text renders correctly in French (default)
- [ ] Click **EN** in the header and verify the entire site switches to English
- [ ] Click **FR** to switch back and verify it reverts correctly
- [ ] Test on mobile (hamburger menu) — language toggle should appear inside the mobile menu